### PR TITLE
fix: use secure URL for images

### DIFF
--- a/app/src/main/java/com/oliverchico/mobileproject/ui/MovieDetailActivity.java
+++ b/app/src/main/java/com/oliverchico/mobileproject/ui/MovieDetailActivity.java
@@ -128,9 +128,9 @@ public class MovieDetailActivity extends AppCompatActivity {
         tvReleaseDate.setText(releaseDate.toString());
         tvStatus.setText(movie.getStatus());
         rbVoteAverage.setRating(movie.getVoteAverage() / 2);
-        String posterUrl = config.getBaseUrl() + config.getPosterSizes()
+        String posterUrl = config.getSecureBaseUrl() + config.getPosterSizes()
                 .get(4) + movie.getPosterPath();
-        String backdropUrl = config.getBaseUrl() + config.getBackdropSizes()
+        String backdropUrl = config.getSecureBaseUrl() + config.getBackdropSizes()
                 .get(2) + movie.getBackdropPath();
         Glide.with(this)
                 .load(posterUrl)

--- a/app/src/main/java/com/oliverchico/mobileproject/ui/PopularAdapter.java
+++ b/app/src/main/java/com/oliverchico/mobileproject/ui/PopularAdapter.java
@@ -60,7 +60,7 @@ public class PopularAdapter extends RecyclerView.Adapter<PopularAdapter.ViewHold
 
         public void bind(Movie movie) {
             Glide.with(itemView)
-                    .load(configuration.getBaseUrl() + configuration.getPosterSizes().get(4) + movie.getPosterPath())
+                    .load(configuration.getSecureBaseUrl() + configuration.getPosterSizes().get(4) + movie.getPosterPath())
                     .error(R.drawable.ic_launcher_background)
                     .into(ivBackdrop);
             itemView.setOnClickListener(v -> v.getContext().startActivity(MovieDetailActivity.newIntent(v.getContext(), movie)));


### PR DESCRIPTION
When using API level 32 or 33, `Glide` will failed to load images.

This is resolved when using `getSecureBaseURL()` instead.

![anime-anime-girl](https://user-images.githubusercontent.com/75809885/212631287-71b80b0a-a1b9-4c08-9014-aaf9b437ca83.gif)
